### PR TITLE
Fix -Game over when changing direction too fast #5- issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ def draw_snake(snake_block, snake_list):
     for x in snake_list:
         pygame.draw.rect(screen, GREEN, [x[0], x[1], snake_block, snake_block])
 
-# Display game over message
+# Display game over message, now centered and with a smaller font
 def message(msg, color):
     small_font_style = pygame.font.SysFont(None, 30)  # Use a smaller font size
     mesg = small_font_style.render(msg, True, color)
@@ -66,6 +66,7 @@ def gameLoop():
     y1_change = 0
 
     current_direction = RIGHT  # Start the snake heading to the right
+    direction_locked = False  # Prevent quick direction changes in the same frame
 
     snake_list = []
     snake_length = 1
@@ -93,24 +94,28 @@ def gameLoop():
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 game_over = True
-            if event.type == pygame.KEYDOWN:
+            if event.type == pygame.KEYDOWN and not direction_locked:  # Allow direction change only if not locked
                 # Check direction and prevent turning to the opposite direction
                 if event.key == pygame.K_LEFT and current_direction != RIGHT:
                     x1_change = -SNAKE_SIZE
                     y1_change = 0
                     current_direction = LEFT
+                    direction_locked = True  # Lock direction change until next movement
                 elif event.key == pygame.K_RIGHT and current_direction != LEFT:
                     x1_change = SNAKE_SIZE
                     y1_change = 0
                     current_direction = RIGHT
+                    direction_locked = True
                 elif event.key == pygame.K_UP and current_direction != DOWN:
                     y1_change = -SNAKE_SIZE
                     x1_change = 0
                     current_direction = UP
+                    direction_locked = True
                 elif event.key == pygame.K_DOWN and current_direction != UP:
                     y1_change = SNAKE_SIZE
                     x1_change = 0
                     current_direction = DOWN
+                    direction_locked = True
 
         # Check if the snake hits the boundary
         if x1 >= SCREEN_WIDTH or x1 < 0 or y1 >= SCREEN_HEIGHT or y1 < 0:
@@ -146,6 +151,9 @@ def gameLoop():
             snake_length += 1
 
         clock.tick(SNAKE_SPEED)
+
+        # Unlock direction change after moving the snake
+        direction_locked = False  # Once snake has moved, unlock direction change
 
     pygame.quit()
     quit()


### PR DESCRIPTION
The issue you’re describing happens because the snake is trying to process multiple keypresses too quickly, causing it to collide with itself before it has a chance to update its position. We can fix this by ensuring that the snake only updates its direction once per frame, rather than responding to every key press, and that it properly moves before another direction change is allowed.

Solution:

	1.	Add a delay between direction changes: Ensure that the snake must move one unit (i.e., one frame) before it can accept another direction change.
	2.	Lock the direction until the next frame: This prevents the snake from registering multiple key presses in a single frame, avoiding quick changes that could lead to self-collision.

Step 1: Add a “direction locked” flag

We will introduce a flag that ensures the snake can only change direction after moving a full block (one frame).

Step 2: Update the direction change logic

The direction should only update once per frame, and we will reset the “direction locked” flag after the snake has moved.


Fixes implemented:
1.	Direction Locking:
	•	A new variable, direction_locked, is added to control whether the snake can change direction.
	•	The direction is locked after a keypress is detected, preventing a second keypress until the snake has moved to its next position.
	2.	Unlock Direction After Movement:
	•	After each frame (movement of the snake), direction_locked is set to False, allowing another direction change in the next frame.
	3.	Avoid Quick Direction Change Bug:
	•	Now, even if two keys are pressed quickly in succession, the snake will be forced to move one block before it can change direction again, preventing the self-collision issue caused by fast keypresses.
