### PR TITLE
Fix the lef key doesn't working on game start

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ def gameLoop():
     x1_change = 0
     y1_change = 0
 
-    current_direction = RIGHT  # Start the snake heading to the right
+    current_direction = None  # Start with no direction, waiting for key press
     direction_locked = False  # Prevent quick direction changes in the same frame
 
     snake_list = []
@@ -147,7 +147,7 @@ def gameLoop():
             if event.type == pygame.QUIT:
                 game_over = True
             if event.type == pygame.KEYDOWN and not direction_locked:  # Allow direction change only if not locked
-                # Check direction and prevent turning to the opposite direction
+                # Ignore the opposite direction check when the snake hasn't started moving (current_direction is None)
                 if event.key == pygame.K_LEFT and current_direction != RIGHT:
                     x1_change = -SNAKE_SIZE
                     y1_change = 0


### PR DESCRIPTION
Fix:

We need to handle the left key correctly by ensuring that the snake can move left from a stationary position when the game starts.

Solution:

	•	We should initialize the snake direction to None and only allow the movement when the player presses a valid key.
	•	The game should ignore the direction check (that prevents opposite directions) when the snake hasn’t started moving yet.

Key Changes:

	1.	Initial direction handling (current_direction):
	•	current_direction is set to None initially, meaning the snake won’t move until a key is pressed.
	•	When the snake is stationary, the opposite direction check is ignored, allowing the snake to move left if the left arrow key is pressed first.
	2.	Direction change logic:
	•	The snake can now start moving in any direction, including left, from the initial stationary state.

Testing:

	•	Start the game and press the Left key first. The snake should now start moving to the left without issue.
	•	All other directions should still function properly.